### PR TITLE
Add option to remove empty subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2019-10-26
+### Added
+- #11 Optional `--remove-directories` flag to remove any empty subdirectories when doing a recursive search.
+
 ## [v1.1.0] - 2019-01-20
 ### Added
 - #9 Optional `--case-insensitive` flag to look for file extensions in any case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v1.1.0] - 2019-01-20
 ### Added
- - #9 Optional --case-insensitive flag to look for file extensions in any case.
+- #9 Optional `--case-insensitive` flag to look for file extensions in any case.
 
 ## [v1.0.0] - 2018-07-24
 ### Added
- - #7 In addition to logging to stdout, logs will now also go to the Windows Event Log
+- #7 In addition to logging to stdout, logs will now also go to the Windows Event Log
 
 ## [v0.2.2] - 2017-10-10
 ### Added
-
-- Logging additional information;  path, version #, build #, older-than flag, recursive flag.
+- Logging additional information;  `path`, `version #`, `build #`, `older-than` flag, `recursive` flag.
 
 ## [v0.2.1] - 2017-10-09
 ### Added
-
 - Logging message if there are no files to be deleted.
 
 ## [v0.2.0] - 2017-10-03
 ### Added
-
 - Version flag to print version and build number.
 - Accept a wildcard extension to delete all files within a specified path.
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ Small app to delete specified files older than the specified number days from a 
 
 Command line flags are used to pass in parameters.
 
-| Flag               | Description                                                              | Default Value |
-| ------------------ | ------------------------------------------------------------------------ | ------------- |
-| ext                | Files matching the extension will be deleted. Use * to match all files.  | none          |
-| older-than         | Files which are older than the number of days specified will be deleted. | none          |
-| path               | Path to search for files to be deleted. DO NOT use trailing slashes.     | none          |
-| recursive          | Search directory path recursively.                                       | false         |
-| test               | Carry out a test run.  No files will be deleted.                         | false         |
-| debug              | Enable debug logging.                                                    | false         |
-| version            | Display version and build number                                         | false         |
-| case-insensitive   | Match file extensions regardless of case                                 | false         |
-| remove-directories | Remove **empty** subdirectories when doing a recursive search            | false         |
+| Flag               | Description                                                                             | Default Value | Required? |
+| ------------------ | --------------------------------------------------------------------------------------- | ------------- | --------- |
+| ext                | Files matching the extension will be deleted. Use * to match all files.                 | none          | yes       |
+| older-than         | Files which are older than the number of days specified will be deleted.                | none          | yes       |
+| path               | Path to search for files to be deleted. DO NOT use trailing slashes.                    | none          | yes       |
+| recursive          | Search directory path recursively.                                                      | false         | no        |
+| test               | Carry out a test run.  No files will be deleted.                                        | false         | no        |
+| debug              | Enable debug logging.                                                                   | false         | no        |
+| version            | Display version and build number                                                        | false         | no        |
+| case-insensitive   | Match file extensions regardless of case                                                | false         | no        |
+| remove-directories | Remove **empty** subdirectories, those without files in, when doing a recursive search. | false         | no        |
 
-For example; delete files with the **.log** file extension, ignoring case, which are older than **30** days and are anywhere within the **c:\logs** directory.  Additionally remove any empty directories within the **c:\logs** directory.
+For example; delete files with the **.log** file extension, ignoring case, which are older than **30** days and are anywhere within the **c:\logs** directory.  Additionally remove any empty directories, those not containing files, within the **c:\logs** directory.
 
 ````Batchfile
 housekeeper.exe --ext "log" --older-than 30 --path "c:\logs" --recursive --case-insensitive --remove-directories

--- a/README.md
+++ b/README.md
@@ -6,21 +6,22 @@ Small app to delete specified files older than the specified number days from a 
 
 Command line flags are used to pass in parameters.
 
-| Flag             | Description                                                              | Default Value |
-| ---------------- | ------------------------------------------------------------------------ | ------------- |
-| ext              | Files matching the extension will be deleted. Use * to match all files.  | none          |
-| older-than       | Files which are older than the number of days specified will be deleted. | none          |
-| path             | Path to search for files to be deleted.                                  | none          |
-| recursive        | Search directory path recursively.                                       | false         |
-| test             | Carry out a test run.  No files will be deleted.                         | false         |
-| debug            | Enable debug logging.                                                    | false         |
-| version          | Display version and build number                                         | false         |
-| case-insensitive | Match file extensions regardless of case                                 | false         |
+| Flag               | Description                                                              | Default Value |
+| ------------------ | ------------------------------------------------------------------------ | ------------- |
+| ext                | Files matching the extension will be deleted. Use * to match all files.  | none          |
+| older-than         | Files which are older than the number of days specified will be deleted. | none          |
+| path               | Path to search for files to be deleted.                                  | none          |
+| recursive          | Search directory path recursively.                                       | false         |
+| test               | Carry out a test run.  No files will be deleted.                         | false         |
+| debug              | Enable debug logging.                                                    | false         |
+| version            | Display version and build number                                         | false         |
+| case-insensitive   | Match file extensions regardless of case                                 | false         |
+| remove-directories | Remove **empty** subdirectories when doing a recursive search            | false         |
 
-For example; delete files with the **.log** file extension, ignoring case, which are older than **30** days and are anywhere within the **c:\logs** directory.
+For example; delete files with the **.log** file extension, ignoring case, which are older than **30** days and are anywhere within the **c:\logs** directory.  Additionally remove any empty directories within the **c:\logs** directory.
 
 ````Batchfile
-housekeeper.exe --ext "log" --older-than 30 --path "c:\logs" --recursive --case-insensitive
+housekeeper.exe --ext "log" --older-than 30 --path "c:\logs" --recursive --case-insensitivem --remove-directories
 ````
 
 Logs are printed to the Windows Event Log (if on Windows) and stdout which means you can do with them as you wish.  A good option is to pipe the output to another application which sends the logs where you want.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Command line flags are used to pass in parameters.
 For example; delete files with the **.log** file extension, ignoring case, which are older than **30** days and are anywhere within the **c:\logs** directory.  Additionally remove any empty directories within the **c:\logs** directory.
 
 ````Batchfile
-housekeeper.exe --ext "log" --older-than 30 --path "c:\logs" --recursive --case-insensitivem --remove-directories
+housekeeper.exe --ext "log" --older-than 30 --path "c:\logs" --recursive --case-insensitive --remove-directories
 ````
 
 Logs are printed to the Windows Event Log (if on Windows) and stdout which means you can do with them as you wish.  A good option is to pipe the output to another application which sends the logs where you want.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Command line flags are used to pass in parameters.
 | ------------------ | ------------------------------------------------------------------------ | ------------- |
 | ext                | Files matching the extension will be deleted. Use * to match all files.  | none          |
 | older-than         | Files which are older than the number of days specified will be deleted. | none          |
-| path               | Path to search for files to be deleted.                                  | none          |
+| path               | Path to search for files to be deleted. DO NOT use trailing slashes.     | none          |
 | recursive          | Search directory path recursively.                                       | false         |
 | test               | Carry out a test run.  No files will be deleted.                         | false         |
 | debug              | Enable debug logging.                                                    | false         |
@@ -23,6 +23,8 @@ For example; delete files with the **.log** file extension, ignoring case, which
 ````Batchfile
 housekeeper.exe --ext "log" --older-than 30 --path "c:\logs" --recursive --case-insensitive --remove-directories
 ````
+
+**NOTE:** Do not use trailing slashes in the path.  On Windows this causes the final `"` to be escaped resulting in Housekeeper thinking that the rest of the command is all part of the `path` flag.  This isn't a Housekeeper limitation technically, it's how Windows works.
 
 Logs are printed to the Windows Event Log (if on Windows) and stdout which means you can do with them as you wish.  A good option is to pipe the output to another application which sends the logs where you want.
 

--- a/is_dir_empty.go
+++ b/is_dir_empty.go
@@ -1,22 +1,14 @@
 package main
 
 import (
-	"io"
-	"os"
+	"io/ioutil"
 )
 
 func isDirEmpty(path string) (bool, error) {
-	f, err := os.Open(path)
+	entries, err := ioutil.ReadDir(path)
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
 
-	// Read a single file and if it is EOF, the directory is empty
-	_, err = f.Readdir(1)
-	if err == io.EOF {
-		return true, nil
-	}
-
-	return false, err
+	return len(entries) == 0, nil
 }

--- a/is_dir_empty.go
+++ b/is_dir_empty.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 )
 
@@ -10,5 +11,23 @@ func isDirEmpty(path string) (bool, error) {
 		return false, err
 	}
 
-	return len(entries) == 0, nil
+	// In order to tell whether a directory is empty, we need to check any sub directories as well.
+	for _, dir := range entries {
+		if dir.IsDir() == false {
+			return false, nil
+		}
+
+		subdir := fmt.Sprintf("%s\\%s", path, dir.Name())
+
+		empty, err := isDirEmpty(subdir)
+		if err != nil {
+			return false, err
+		}
+
+		if empty == false {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/is_dir_empty.go
+++ b/is_dir_empty.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"io"
+	"os"
+)
+
+func isDirEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	// Read a single file and if it is EOF, the directory is empty
+	_, err = f.Readdir(1)
+	if err == io.EOF {
+		return true, nil
+	}
+
+	return false, err
+}

--- a/main_linux.go
+++ b/main_linux.go
@@ -150,6 +150,13 @@ func main() {
 				continue
 			}
 
+			// There is a good chance that a subfolder has already been deleted as the slice of folders is listed from the root down.
+			// So we may well have deleted the parent of a subfolder, because all of its subfolders were empty, before we get to check the subfolder.
+			// Checking whether the folder we want to act on already exists or not, removes the possibility of an error.
+			if _, err := os.Stat(file.path); os.IsNotExist(err) {
+				continue
+			}
+
 			empty, err := isDirEmpty(file.path)
 			if err != nil {
 				level.Error(logger).Log("folder", file.path, "msg", err, "task", "is directory empty?")
@@ -169,7 +176,7 @@ func main() {
 				continue
 			}
 
-			err = os.Remove(file.path)
+			err = os.RemoveAll(file.path)
 			if err != nil {
 				level.Error(logger).Log("folder", file.path, "msg", err)
 			} else {

--- a/main_linux.go
+++ b/main_linux.go
@@ -150,14 +150,14 @@ func main() {
 				continue
 			}
 
-			e, err := isDirEmpty(file.path)
+			empty, err := isDirEmpty(file.path)
 			if err != nil {
 				level.Error(logger).Log("folder", file.path, "msg", err, "task", "is directory empty?")
 
 				continue
 			}
 
-			if e == false {
+			if empty == false {
 				continue
 			}
 

--- a/main_windows.go
+++ b/main_windows.go
@@ -31,7 +31,7 @@ func main() {
 		versionFlg         = flag.Bool("version", false, "Display application version")
 		olderThanFlg       = flag.Int("older-than", 0, "Number of days that a file should be older than in order to be deleted")
 		extFlg             = flag.String("ext", "", "File extension to be deleted. Use * to match all files")
-		pathFlg            = flag.String("path", "", "Path to search for files to be deleted")
+		pathFlg            = flag.String("path", "", "Path to search for files to be deleted; DO NOT use trailing slashes")
 		recursiveFlg       = flag.Bool("recursive", false, "Search all subfolders as well")
 		caseInsensitiveFlg = flag.Bool("case-insensitive", false, "Match files regardless of case")
 		testFlg            = flag.Bool("test", false, "Test run")

--- a/main_windows.go
+++ b/main_windows.go
@@ -49,8 +49,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	//if *olderThanFlg == 0 || *extFlg == "" || *pathFlg == "" {
-	if *extFlg == "" || *pathFlg == "" {
+	if *olderThanFlg == 0 || *extFlg == "" || *pathFlg == "" {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}

--- a/main_windows.go
+++ b/main_windows.go
@@ -35,6 +35,7 @@ func main() {
 		recursiveFlg       = flag.Bool("recursive", false, "Search all subfolders as well")
 		caseInsensitiveFlg = flag.Bool("case-insensitive", false, "Match files regardless of case")
 		testFlg            = flag.Bool("test", false, "Test run")
+		removeDirsFlg      = flag.Bool("remove-directories", false, "Remove empty directories?")
 		debug              = flag.Bool("debug", false, "Enable debugging?")
 		logger             log.Logger
 		fileInfo           []fileData
@@ -48,7 +49,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *olderThanFlg == 0 || *extFlg == "" || *pathFlg == "" {
+	//if *olderThanFlg == 0 || *extFlg == "" || *pathFlg == "" {
+	if *extFlg == "" || *pathFlg == "" {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
@@ -136,22 +138,78 @@ func main() {
 
 	// Now process the file list
 	for _, file := range fileInfo {
-		if !file.info.IsDir() && file.info.ModTime().Before(d) {
-			fileExt := filepath.Ext(file.path)
+		if file.info.IsDir() {
+			continue
+		}
 
-			if *caseInsensitiveFlg {
-				fileExt = strings.ToLower(fileExt)
-				ext = strings.ToLower(ext)
+		if file.info.ModTime().After(d) {
+			continue
+		}
+
+		fileExt := filepath.Ext(file.path)
+
+		if *caseInsensitiveFlg {
+			fileExt = strings.ToLower(fileExt)
+			ext = strings.ToLower(ext)
+		}
+
+		if ext != ".*" && fileExt != ext {
+			continue
+		}
+
+		processed = processed + 1
+
+		if *testFlg {
+			level.Info(logger).Log("file", file.path, "msg", "test: would be deleted")
+
+			msg := fmt.Sprintf("testing: %s would be deleted", file.path)
+			el.Info(5, msg)
+
+			continue
+		}
+
+		err := os.Remove(file.path)
+		if err != nil {
+			level.Error(logger).Log("file", file.path, "msg", err)
+
+			msg := fmt.Sprintf("unable to delete %s; %s", file.path, err)
+			el.Error(6, msg)
+		} else {
+			level.Info(logger).Log("file", file.path, "msg", "deleted")
+
+			msg := fmt.Sprintf("%s deleted", file.path)
+			el.Info(7, msg)
+		}
+	}
+
+	if *removeDirsFlg && *recursiveFlg {
+		for _, file := range fileInfo {
+			if !file.info.IsDir() {
+				continue
 			}
 
-			if ext != ".*" && fileExt != ext {
+			if file.path == *pathFlg {
+				continue
+			}
+
+			e, err := isDirEmpty(file.path)
+			if err != nil {
+				level.Error(logger).Log("folder", file.path, "msg", err, "task", "is directory empty?")
+
+				msg := fmt.Sprintf("unable to check whether folder, %s, is empty; %s", file.path, err)
+				el.Error(8, msg)
+
+				continue
+			}
+
+			if e == false {
 				continue
 			}
 
 			processed = processed + 1
 
 			if *testFlg {
-				level.Info(logger).Log("file", file.path, "msg", "test: would be deleted")
+				level.Info(logger).Log("folder", file.path, "msg", "test: would be deleted")
 
 				msg := fmt.Sprintf("testing: %s would be deleted", file.path)
 				el.Info(5, msg)
@@ -159,14 +217,14 @@ func main() {
 				continue
 			}
 
-			err := os.Remove(file.path)
+			err = os.Remove(file.path)
 			if err != nil {
-				level.Error(logger).Log("file", file.path, "msg", err)
+				level.Error(logger).Log("folder", file.path, "msg", err)
 
 				msg := fmt.Sprintf("unable to delete %s; %s", file.path, err)
 				el.Error(6, msg)
 			} else {
-				level.Info(logger).Log("file", file.path, "msg", "deleted")
+				level.Info(logger).Log("folder", file.path, "msg", "deleted")
 
 				msg := fmt.Sprintf("%s deleted", file.path)
 				el.Info(7, msg)

--- a/main_windows.go
+++ b/main_windows.go
@@ -191,7 +191,7 @@ func main() {
 				continue
 			}
 
-			e, err := isDirEmpty(file.path)
+			empty, err := isDirEmpty(file.path)
 			if err != nil {
 				level.Error(logger).Log("folder", file.path, "msg", err, "task", "is directory empty?")
 
@@ -201,7 +201,7 @@ func main() {
 				continue
 			}
 
-			if e == false {
+			if empty == false {
 				continue
 			}
 

--- a/main_windows.go
+++ b/main_windows.go
@@ -191,6 +191,13 @@ func main() {
 				continue
 			}
 
+			// There is a good chance that a subfolder has already been deleted as the slice of folders is listed from the root down.
+			// So we may well have deleted the parent of a subfolder, because all of its subfolders were empty, before we get to check the subfolder.
+			// Checking whether the folder we want to act on already exists or not, removes the possibility of an error.
+			if _, err := os.Stat(file.path); os.IsNotExist(err) {
+				continue
+			}
+
 			empty, err := isDirEmpty(file.path)
 			if err != nil {
 				level.Error(logger).Log("folder", file.path, "msg", err, "task", "is directory empty?")
@@ -216,7 +223,7 @@ func main() {
 				continue
 			}
 
-			err = os.Remove(file.path)
+			err = os.RemoveAll(file.path)
 			if err != nil {
 				level.Error(logger).Log("folder", file.path, "msg", err)
 

--- a/make.bat
+++ b/make.bat
@@ -2,7 +2,7 @@
 SETLOCAL
 
 set APP=Housekeeper
-set VERSION=1.1.0
+set VERSION=1.2.0
 set BINARY-X86=%APP%_%VERSION%.windows.386.exe
 set BINARY-X64=%APP%_%VERSION%.windows.amd64.exe
 


### PR DESCRIPTION
Closes #11

Optional `--remove-directories` flag to remove any empty subdirectories when doing a recursive search.